### PR TITLE
Add encrypt & decrypt subcommands for pipe interactions

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -194,10 +194,10 @@
           }
           function checkid {
             if [[ -z "$identityFile" ]]; then
-              echo "No given identity file."
+              echo "No given identity file." >&2
               exit 1
             elif ! [[ -e "$identityFile" ]]; then
-              echo "Identity file does not exist."
+              echo "Identity file does not exist." >&2
               exit 1
             fi
           }
@@ -224,12 +224,12 @@
             create)
               tmpsec="$(${pkgs.coreutils}/bin/mktemp)"
               if ! ${edit} "$tmpsec"; then
-                echo "Editor exited with non-zero status. Abandoning."
+                echo "Editor exited with non-zero status. Abandoning." >&2
                 status=1
               else
                 tmpfin="$(${pkgs.coreutils}/bin/mktemp)"
                 if ! eval ${ageBin} -e $recips "$tmpsec" > "$tmpfin"; then
-                  echo "Encrypt failed with non-zero status. Abandoning."
+                  echo "Encrypt failed with non-zero status. Abandoning." >&2
                   status=1
                 else
                   ${pkgs.coreutils}/bin/mv "$tmpfin" "''${positionalOpts[1]}"
@@ -240,12 +240,12 @@
               checkid
               tmpsec="$(${pkgs.coreutils}/bin/mktemp)"
               if ! eval ${ageBin} -d -i "$identityFile" "''${positionalOpts[1]}" > "$tmpsec"; then
-                echo "Decrypt failed with non-zero status. Abandoning."
+                echo "Decrypt failed with non-zero status. Abandoning." >&2
                 status=1
               else
                 tmpfin="$(${pkgs.coreutils}/bin/mktemp)"
                 if ! eval ${ageBin} -e $recips "$tmpsec" > "$tmpfin"; then
-                  echo "Reencrypt failed with non-zero status. Abandoning."
+                  echo "Reencrypt failed with non-zero status. Abandoning." >&2
                   status=1
                 else
                   ${pkgs.coreutils}/bin/mv "$tmpfin" "''${positionalOpts[1]}"
@@ -256,16 +256,16 @@
               checkid
               tmpsec="$(${pkgs.coreutils}/bin/mktemp)"
               if ! eval ${ageBin} -d -i "$identityFile" "''${positionalOpts[1]}" > "$tmpsec"; then
-                echo "Decrypt failed with non-zero status. Abandoning."
+                echo "Decrypt failed with non-zero status. Abandoning." >&2
                 status=1
               else
                 if ! ${edit} "$tmpsec"; then
-                  echo "Editor exited with non-zero status. Abandoning."
+                  echo "Editor exited with non-zero status. Abandoning." >&2
                   status=1
                 else
                   tmpfin="$(${pkgs.coreutils}/bin/mktemp)"
                   if ! eval ${ageBin} -e $recips "$tmpsec" > "$tmpfin"; then
-                    echo "Encrypt failed with non-zero status. Abandoning."
+                    echo "Encrypt failed with non-zero status. Abandoning." >&2
                     status=1
                   else
                     ${pkgs.coreutils}/bin/mv "$tmpfin" "''${positionalOpts[1]}"
@@ -274,7 +274,7 @@
               fi
             ;;
             *)
-              echo "Unknown action '""''${positionalOpts[0]}.'"
+              echo "Unknown action '""''${positionalOpts[0]}.'" >&2
             ;;
           esac
           ${pkgs.coreutils}/bin/rm -f "$tmpfin"


### PR DESCRIPTION
This PR introduces two sub-commands:

- `encrypt` is useful when another tool should be used to generate a random key
	- e.g. to generate a Wireguard private key: `wg genkey | nix run .#secrix encrypt -s hostname -u name wg.key.age`
- `decrypt` is useful for plumbing a secret into another tool or to quickly inspect it
	- e.g. to get a Wireguard public key: `nix run .#secrix decrypt -i ~/.ssh/id_ed25519 wg.key.age | wg pubkey > wg.pub`
	- I would also argue that it is, albeit be it a little bit, better to use `decrypt` instead of `edit` because the secret is never stored into a temporary file where another process could easily capture it.
	- It might also be more useful than `edit` as it does not change the age file & so cannot introduce any unwanted changes/commits.

To prevent any error messages from "leaking" into stdout, I ensured that all error echos are redirected to stderr.