### PR TITLE
Prevent incompatible Binaries for encryption

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -310,7 +310,7 @@
         default = import ./module.nix;
       };
       checks.x86_64-linux = {
-        e2e-test = pkgs.nixosTest {
+        e2e-test = pkgs.testers.nixosTest {
           name = "secrix-e2e-test";
           extraPythonPackages = p: [ p.termcolor ];
           nodes = {


### PR DESCRIPTION
During encryption it was possible for secrix to choose a age-binary from a different system configuration that the  host system; this would prevent execution without compatible binfmt defintions, which may be unreliable regardless.

This PR filters the avalible agebins to use only compatible system defintions.